### PR TITLE
Parser2

### DIFF
--- a/src/make
+++ b/src/make
@@ -1,0 +1,7 @@
+#!/bin/bash
+ocamllex scanner.mll # create scanner.ml
+ocamlyacc parser.mly # create parser.ml and parser.mli
+ocamlc -c ast.ml # compile AST types
+ocamlc -c parser.mli # compile parser types
+ocamlc -c scanner.ml # compile the scanner
+ocamlc -c parser.ml # compile the parser

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -36,7 +36,7 @@ sexpr:
 | IF expr expr expr		{ If($2, $3, $4) }
 | FOR expr expr expr		{ For($2, $3, $4) }
 | WHILE expr expr		{ While($2, $3) }
-| FUNC LPAREN formals_opt RPAREN LPAREN expr RPAREN { Fdecl(List.rev $3, $6) }
+| FUNC LPAREN formals_opt RPAREN expr { Fdecl(List.rev $3, $5) }
 | call				{ $1 }
 
 expr:


### PR DESCRIPTION
Adding make file and fixing an error in the Fdecl parsing - now,  function declarations do NOT need parens around the body