### PR TITLE
fixing stringify to print ListOp when encountering listop in AST

### DIFF
--- a/src/stringify.ml
+++ b/src/stringify.ml
@@ -18,7 +18,7 @@ in
   | Assign(str, exp) -> concat ["Assign("; str; ", "; stringify exp; ""]
   | Binop(exp1, op, exp2) -> concat ["Binop("; stringify exp1; ", "; stringify_op op; ", "; stringify exp2; ")"]
   | Eval(str, el) -> concat ["Eval("; str; ", "; stringify (List(el)); ")"]
-  | ListOp(o, el) -> concat ["Evalarith("; stringify_op o; ", "; stringify (List(el)); ")"]
+  | ListOp(o, el) -> concat ["ListOp("; stringify_op o; ", "; stringify (List(el)); ")"]
   | Nil -> "Nil"
   | List(expl) -> concat ["List("; (String.concat ", " (List.map (fun x -> stringify x) expl)); ")"]
   | Fdecl(args, e) -> concat ["Fdecl(["; String.concat ", " (List.map (fun x -> concat ["\""; x; "\""]) args); "], "; stringify e; ")"]


### PR DESCRIPTION
Renaming the last occurrence of "EvalArith" (in print statement in stringify.ml) and replacing with "ListOp"