### PR TITLE
Using OCaml's boolean type for our Boolean

### DIFF
--- a/src/ast.ml
+++ b/src/ast.ml
@@ -1,8 +1,6 @@
 type op = Add | Sub | Mult | Div | Addf | Subf | Multf | Divf 
 	| Equal | Neq | Less | Leq | Greater | Geq | And | Or | Assign
  
-type bool = true | false
-
 type expr =				(* Expressions *)
   Int of int				(* 4 *)
   | Float of float			(* 4.444 *)


### PR DESCRIPTION
Fixing bug in our AST...we didn't need to define type boolean since it already exists in OCaml