### PR TITLE
Fixing unary minus for ints/floats for infix expressions

### DIFF
--- a/src/parser.mly
+++ b/src/parser.mly
@@ -106,7 +106,8 @@ args:
   
 infix_expr:
   constant			{ $1 }
-| MINUS constant		{ Int(-1 * $2) }
+| MINUS INT			{ Int(-1 * $2) }
+| MINUS FLOAT			{ Float(-1.0 * $2) }
 | LPAREN infix_expr RPAREN	{ $2 }
 | ID ASSIGN infix_expr		{ Assign($1, $3) }
 | infix_expr PLUS infix_expr	{ Binop($1, Add, $3) }

--- a/src/parser.mly
+++ b/src/parser.mly
@@ -107,7 +107,7 @@ args:
 infix_expr:
   constant			{ $1 }
 | MINUS INT			{ Int(-1 * $2) }
-| MINUS FLOAT			{ Float(-1.0 * $2) }
+| MINUS FLOAT			{ Float(-1.0 *. $2) }
 | LPAREN infix_expr RPAREN	{ $2 }
 | ID ASSIGN infix_expr		{ Assign($1, $3) }
 | infix_expr PLUS infix_expr	{ Binop($1, Add, $3) }


### PR DESCRIPTION
Fixing unary minus operator for ints/floats, within curly expressions